### PR TITLE
Handle closed message-box

### DIFF
--- a/gui-pkg-manager-lib/pkg/gui/private/by-list.rkt
+++ b/gui-pkg-manager-lib/pkg/gui/private/by-list.rkt
@@ -236,24 +236,24 @@
       (define db-catalogs (db:get-catalogs))
       (unless (equal? (list->set db-catalogs)
                       (list->set user-catalogs))
-        (when (= 1 (message-box/custom "Package Catalogs"
-                                       (~a
-                                        (string-constant install-pkg-update-catalogs?)
-                                        "\n\n"
-                                        (string-constant install-pkg-currently-configured-are) ":\n"
-                                        (apply ~a
-                                               (for/list ([url user-catalogs])
-                                                 (~a "  " url "\n")))
-                                        "\n"
-                                        (string-constant install-pkg-database-recorded-are) ":\n"
-                                        (apply ~a
-                                               (for/list ([url db-catalogs])
-                                                 (~a "  " url "\n"))))
-                                       (string-constant install-pkg-update-catalogs)
-                                       (string-constant install-pkg-do-not-update-catalogs)
-                                       #f
-                                       (get-top-level-window)
-                                       '(caution default=1)))
+        (when (equal? 1 (message-box/custom "Package Catalogs"
+                                            (~a
+                                             (string-constant install-pkg-update-catalogs?)
+                                             "\n\n"
+                                             (string-constant install-pkg-currently-configured-are) ":\n"
+                                             (apply ~a
+                                                    (for/list ([url user-catalogs])
+                                                      (~a "  " url "\n")))
+                                             "\n"
+                                             (string-constant install-pkg-database-recorded-are) ":\n"
+                                             (apply ~a
+                                                    (for/list ([url db-catalogs])
+                                                      (~a "  " url "\n"))))
+                                            (string-constant install-pkg-update-catalogs)
+                                            (string-constant install-pkg-do-not-update-catalogs)
+                                            #f
+                                            (get-top-level-window)
+                                            '(caution default=1)))
           (db:set-catalogs! user-catalogs)
           (update-db-package-list))))
 


### PR DESCRIPTION
In DrRacket, in the window of the "Package Manager" > "Copy from version", if a push the "Remove" button and then I close the messagebox with the "x" in the top right, I get this error:

    =: contract violation
      expected: number?
      given: #f
      argument position: 2nd
      other arguments...:
       1
      context...:
       C:\Program Files\Racket\share\pkgs\gui-pkg-manager-lib\
       pkg\gui\private\by-migrate.rkt:56:4:remove-package-info

I think I fixed the error and another similar use of `message-box/custom`.

There are also two instances of `message-box` but I don't understand the flow enought to be sure if they need a fix too: [by-list.rkt#L280](https://github.com/racket/gui-pkg-manager/blob/0aed4636861dbf14104f80e85f6e265429c90293/gui-pkg-manager-lib/pkg/gui/private/by-list.rkt#L280) and [by-source.rkt#L309](https://github.com/racket/gui-pkg-manager/blob/f3a5c1b1cb491ab1249e02536b727e688503fffc/gui-pkg-manager-lib/pkg/gui/private/by-source.rkt#L309)