### PR TITLE
Change `pkg-remove-command` to `pkg-uninstall-command`

### DIFF
--- a/gui-pkg-manager-lib/pkg/gui/private/by-installed.rkt
+++ b/gui-pkg-manager-lib/pkg/gui/private/by-installed.rkt
@@ -192,7 +192,7 @@
                         (string-constant install-pkg-abort-demote)
                         (lambda (names scope)
                           (apply
-                           pkg-remove-command
+                           pkg-uninstall-command
                            #:batch #t
                            #:demote #t
                            #:scope scope
@@ -209,7 +209,7 @@
                                   (really-remove? names #:parent (get-top-level-window)))
                         (lambda (names scope)
                           (apply
-                           pkg-remove-command
+                           pkg-uninstall-command
                            #:batch #t
                            #:scope scope
                            names))))]))

--- a/gui-pkg-manager-lib/pkg/gui/private/by-list.rkt
+++ b/gui-pkg-manager-lib/pkg/gui/private/by-list.rkt
@@ -194,7 +194,7 @@
                           (string-constant install-pkg-abort-remove)
                           (lambda ()
                             (apply
-                             pkg-remove-command
+                             pkg-uninstall-command
                              #:scope scope
                              names)))
                          (set-box! s #f)


### PR DESCRIPTION
Following racket/racket@7d51e0dcba36, change `pkg-remove-command` to `pkg-uninstall-command` instead of using the alias.

Closes racket/drracket#702.
